### PR TITLE
Fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,4 +1,5 @@
 name: Deno Formatting and Linting
+
 permissions:
   contents: read
 

--- a/.github/workflows/deno.yml
+++ b/.github/workflows/deno.yml
@@ -1,4 +1,6 @@
 name: Deno Formatting and Linting
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/Wissididom/GitHub-Workflow-Deleter/security/code-scanning/1](https://github.com/Wissididom/GitHub-Workflow-Deleter/security/code-scanning/1)

To fix the problem, explicitly declare minimal `GITHUB_TOKEN` permissions in the workflow. Since this job only checks out code and runs Deno formatting and linting locally, it only needs read access to repository contents. The recommended general fix is to add `permissions: contents: read` either at the root of the workflow (to apply to all jobs) or inside the `format-and-lint` job.

The single best fix here is to add a workflow‑level `permissions:` block directly under the workflow `name:` and before `on:` in `.github/workflows/deno.yml`. This keeps the configuration simple and ensures any future jobs sharing this workflow default to read‑only repo contents unless they override it. Concretely, edit `.github/workflows/deno.yml` to insert:

```yml
permissions:
  contents: read
```

between line 1 (`name: Deno Formatting and Linting`) and line 3 (`on:`). No imports, methods, or additional definitions are required, since this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
